### PR TITLE
brew-pip experience updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ Install
 Usage
 -----
 
-    brew pip mercurial        # install the latest mercurial package
-    brew pip django==1.2      # install django-1.2
-    brew pip ~/tox-1.3.tar.gz # can install local packages, too
-    brew pip -u django==1.3.1 # upgrade to django-1.3.1
-    brew pip -k ipython       # install ipython, but don't link it (i.e., keg-only)
-    brew rm django            # uninstallation taken care of by homebrew itself
-    brew pip -h               # for help
+    brew pip install mercurial        # install the latest mercurial package
+    brew pip install django==1.2      # install django-1.2
+    brew pip install ~/tox-1.3.tar.gz # can install local packages, too
+    brew pip install -u django==1.3.1 # upgrade to django-1.3.1
+    brew pip install -k ipython       # install ipython, but don't link it (i.e., keg-only)
+    brew pip uninstall django         # uninstall a previously installed package
+    brew pip reinstall django         # reinstall a package
+    brew pip list                     # list installed packages
+    brew pip -h                       # for help
 
 Setup
 -----
@@ -30,7 +32,7 @@ So python can load your installed libraries, you need to update your `PYTHONPATH
 
 And for any scripts to be found, you need to update your `PATH`:
 
-    export PATH=$PATH:$(brew --prefix)/share/python
+    export PATH=$PATH:$(brew --prefix)/bin
 
 But doesn't everybody use virtualenv now?
 -----------------------------------------
@@ -47,7 +49,13 @@ It's the best of both worlds.
 Changelog
 ---------
 
-*In development*
+v0.5.0 *(2019-03-03)*
+
+- Install scripts to `bin` and not `share/python`
+- Add fallback when HOMEBREW_CELLAR is not specified
+- Match cli experience given by brew-cask
+
+v0.4.1 *(2013-12-03)*
 
 - Add a `--version` argument
 - Handles `@rev` syntax correctly

--- a/bin/brew-pip
+++ b/bin/brew-pip
@@ -39,7 +39,7 @@ def main(args):
                package,
                "--build=%s" % build_dir,
                "--install-option=--prefix=%s" % prefix,
-               "--install-option=--install-scripts=%s" % os.path.join(prefix, "share", "python")]
+               "--install-option=--install-scripts=%s" % os.path.join(prefix, "bin")]
 
         if args.verbose:
             print(" ".join(cmd))

--- a/bin/brew-pip
+++ b/bin/brew-pip
@@ -62,12 +62,12 @@ def main(args):
         prefix = os.path.join(HOMEBREW_CELLAR, cellar_package_name, "pypi")
         build_dir = tempfile.mkdtemp(prefix='brew-pip-')
 
-        cmd = ["pip", "install",
+        cmd = ["TMPDIR=/tmp/%s" % build_dir, "pip", "install",
                "-v" if args.verbose else "",
                package,
-               "--build=%s" % build_dir,
-               "--install-option=--prefix=%s" % prefix,
-               "--install-option=--install-scripts=%s" % os.path.join(prefix, "bin")]
+               "--no-clean",
+               "--prefix=''",
+               "--target=%s" % os.path.join(prefix, "bin")]
 
         if args.verbose:
             print(" ".join(cmd))

--- a/bin/brew-pip
+++ b/bin/brew-pip
@@ -10,9 +10,18 @@ import re
 import os
 import shutil
 import argparse
+import subprocess
 import tempfile
 
-HOMEBREW_CELLAR = os.environ.get("HOMEBREW_CELLAR")
+HOMEBREW_CELLAR = os.environ.get("HOMEBREW_CELLAR", None)
+if not HOMEBREW_CELLAR:
+    try:
+        output = subprocess.check_output(["brew", "--prefix"], stderr=subprocess.STDOUT)
+        HOMEBREW_CELLAR = str(output, "utf-8").splitlines()[0] + "/Cellar"
+    except subprocess.CalledProcessError as e:
+        print("warning: falling back to hardcoded HOMEBREW_CELLAR=/usr/local/Cellar")
+        HOMEBREW_CELLAR = "/usr/local/Cellar"
+
 
 def main(args):
     for package in args.packages:

--- a/bin/brew-pip
+++ b/bin/brew-pip
@@ -4,7 +4,7 @@
 Wrapper around pip to install python distributions within Homebrew.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 import argparse
 import os

--- a/bin/brew-pip
+++ b/bin/brew-pip
@@ -6,11 +6,12 @@ Wrapper around pip to install python distributions within Homebrew.
 
 __version__ = '0.4.0'
 
-import re
-import os
-import shutil
 import argparse
+import os
+import re
+import shutil
 import subprocess
+import sys
 import tempfile
 
 HOMEBREW_CELLAR = os.environ.get("HOMEBREW_CELLAR", None)
@@ -22,8 +23,23 @@ if not HOMEBREW_CELLAR:
         print("warning: falling back to hardcoded HOMEBREW_CELLAR=/usr/local/Cellar")
         HOMEBREW_CELLAR = "/usr/local/Cellar"
 
+def package_folders(package):
+    return next(os.walk("{0}/{1}/".format(HOMEBREW_CELLAR, package)))[1]
 
 def main(args):
+    install_commands = ["install", "reinstall", "upgrade"]
+    list_commands = ["ls", "list"]
+    uninstall_commands = ["reinstall", "remove", "rm", "uninstall", "upgrade"]
+
+    if args.command in list_commands:
+        try:
+            output = subprocess.check_output(["brew", "list"], stderr=subprocess.STDOUT)
+            packages = [l for l in str(output, "utf-8").splitlines() if l.startswith("pip-")]
+            [print(p[4:]) for p in packages if "pypi" in package_folders(p)]
+        except subprocess.CalledProcessError as e:
+            pass
+        return
+
     for package in args.packages:
         # Just the name part of the package (no version info)
         # Django==1.4 -> Django
@@ -34,8 +50,11 @@ def main(args):
         # Django==1.4 -> pip-django
         cellar_package_name = "pip-%s" % package_name.lower()
 
-        if args.upgrade:
+        if args.command in uninstall_commands:
             os.system("brew rm %s" % cellar_package_name)
+
+        if args.command not in install_commands:
+            continue
 
         # Why hard-code the version to "pypi"? Because if you care about
         # versions you're probably already using virtualenv and not
@@ -61,10 +80,20 @@ def main(args):
         shutil.rmtree(build_dir)
 
 if __name__ == "__main__":
+    choices = ["install", "list", "ls", "reinstall", "rm", "remove", "upgrade", "uninstall"]
     parser = argparse.ArgumentParser(prog='brew pip')
     parser.add_argument("--version", action="version", version="%(prog)s v" + __version__)
     parser.add_argument("-v", "--verbose", action="store_true", default=False, help="be verbose")
     parser.add_argument("-k", "--keg-only", action="store_true", default=False, help="don't link files into prefix")
-    parser.add_argument("-u", "--upgrade", action="store_true", default=False, help="upgrade the package")
-    parser.add_argument("packages", nargs='+', help="name of the package(s) to install", metavar="package")
-    main(parser.parse_args())
+    parser.add_argument('command', choices=choices, nargs=1, help="command to run")
+    parser.add_argument("packages", nargs='*', help="name of the package(s) to install", metavar="package")
+    args = parser.parse_args()
+
+    if isinstance(args.command, (list,)):
+        args.command = args.command[0]
+
+    if args.command not in ["list", "ls"] and len(args.packages) == 0:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    main(args)


### PR DESCRIPTION
I pulled in some fixes from other PRs/forks and gave the interface a facelift :)

- Install scripts to `bin` and not `share/python`
- Add fallback when HOMEBREW_CELLAR is not specified
- Match cli experience given by brew-cask
